### PR TITLE
fix: [PIDM-265] Adding clean-up of STAND_IN_STATION before updating it

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-node-cfg-sync
 description: Microservice that sync api-config-cache and standin configuration
 type: application
-version: 0.97.0
-appVersion: 0.1.6
+version: 0.98.0
+appVersion: 0.1.7-PIDM-265
 dependencies:
   - name: microservice-chart
     version: 2.8.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-node-cfg-sync
-    tag: "0.1.6"
+    tag: "0.1.7-PIDM-265"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-node-cfg-sync
-    tag: "0.1.6"
+    tag: "0.1.7-PIDM-265"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-node-cfg-sync
-    tag: "0.1.6"
+    tag: "0.1.7-PIDM-265"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "cfg-sync",
     "description": "Microservice to update configuration schema of Nodo dei Pagamenti",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.1.6"
+    "version": "0.1.7-PIDM-265"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>it.gov.pagopa.node</groupId>
   <artifactId>cfg-sync</artifactId>
-  <version>0.1.6</version>
+  <version>0.1.7-PIDM-265</version>
   <description>Microservice to update configuration schema of Nodo dei Pagamenti</description>
 
   <properties>


### PR DESCRIPTION
This PR contains a little fix on synchronization strategy for Stand-In data. In particular, when the DBs sync operation is required at the moment of the event arrival, the app first execute an API invocation on Stand-In Manager (in order to retrieve all the station currently on _stand-in mode_) and then performs a `saveAll` operation. This last action provide to correctly update the newly added station but it cannot execute the deletion of unregistered stations. This bug leads the station to be always used as stand-in station by Nodo dei Pagamenti, even if the same station is up and running.  
With this fix, a `deleteAll` operation is always made before the execution of `saveAll` operation: this permits to execute a clean-up of unneeded stations and a re-adding of needed ones.

#### List of Changes
 - Added STAND_IN_STATIONS table clean-up before `saveAll` step

#### Motivation and Context
This change is required in order to correctly remove stations no more in stand-in mode.

#### How Has This Been Tested?
 - Tested in UAT environment, via manual triggered event sent via Azure Portal

#### Screenshots (if appropriate):
Table snapshot - Before fix (focus on station `15376371009_17`):
![11 51 09](https://github.com/user-attachments/assets/78dfee24-f8c2-46c7-bb12-31afec1601ad)

Table snapshot - After Fix:
![13 27 50](https://github.com/user-attachments/assets/20402772-93c6-4630-9bff-b0cb51e78588)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
